### PR TITLE
7주차 과제 구현

### DIFF
--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DataSourcePerFileMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/18aff211-cdf2-40bf-b6b4-4dd57460e944/console_1.sql" value="18aff211-cdf2-40bf-b6b4-4dd57460e944" />
-  </component>
-</project>

--- a/src/main/java/org/sopt/common/ErrorCode.java
+++ b/src/main/java/org/sopt/common/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
 
     // 아티클 관련 예외
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "아티클을 찾을 수 없습니다.");
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "아티클을 찾을 수 없습니다."),
+
+    // 댓글 관련 예외
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/sopt/controller/CommentController.java
+++ b/src/main/java/org/sopt/controller/CommentController.java
@@ -1,0 +1,49 @@
+package org.sopt.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.ApiResponse;
+import org.sopt.dto.request.CommentCreateRequest;
+import org.sopt.dto.request.CommentUpdateRequest;
+import org.sopt.dto.response.CommentResponse;
+import org.sopt.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+    
+    // 댓글 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> createComment(@RequestBody CommentCreateRequest req) {
+        Long commentId = commentService.create(
+                req.articleId(), req.memberId(), req.content()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(commentId));
+    }
+    
+    // 댓글 조회
+    @GetMapping("{id}")
+    public ResponseEntity<ApiResponse<CommentResponse>> getComment(@PathVariable("id") Long id) {
+        CommentResponse res = commentService.findById(id);
+        return ResponseEntity.ok(ApiResponse.success(res));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable("id") Long id) {
+        commentService.delete(id);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    // 댓글 수정
+    @PatchMapping("{id}")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(@PathVariable("id") Long id, @RequestBody CommentUpdateRequest req) {
+        CommentResponse res = commentService.update(id, req.content());
+        return ResponseEntity.ok(ApiResponse.success(res));
+    }
+}

--- a/src/main/java/org/sopt/controller/MemberController.java
+++ b/src/main/java/org/sopt/controller/MemberController.java
@@ -6,7 +6,6 @@ import org.sopt.dto.request.MemberCreateRequest;
 import org.sopt.dto.request.MemberUpdateRequest;
 import org.sopt.dto.response.MemberResponse;
 import org.sopt.service.MemberService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -51,7 +50,7 @@ public class MemberController {
     }
 
     // 회원정보 수정
-    @PutMapping("/{memberId}")
+    @PatchMapping("/{memberId}")
     public ResponseEntity<ApiResponse<MemberResponse>> updateMember(
             @PathVariable Long memberId,
             @Valid @RequestBody MemberUpdateRequest req) {

--- a/src/main/java/org/sopt/domain/Article.java
+++ b/src/main/java/org/sopt/domain/Article.java
@@ -1,12 +1,19 @@
 package org.sopt.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
         @Index(name = "idx_article_title", columnList = "title"),
         @Index(name = "idx_article_member_id", columnList = "memberId")
@@ -33,7 +40,8 @@ public class Article {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    protected Article() {}
+    @OneToMany(mappedBy="comment", cascade=CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
 
     private Article(Member member, String title, String content, Tag tag) {
         this.member = member;
@@ -45,29 +53,5 @@ public class Article {
 
     public static Article of(Member member, String title, String content, Tag tag) {
         return new Article(member, title, content, tag);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Member getMember() {
-        return member;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public Tag getTag() {
-        return tag;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
     }
 }

--- a/src/main/java/org/sopt/domain/Article.java
+++ b/src/main/java/org/sopt/domain/Article.java
@@ -40,7 +40,7 @@ public class Article {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy="comment", cascade=CascadeType.ALL)
+    @OneToMany(mappedBy="article", cascade=CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
     private Article(Member member, String title, String content, Tag tag) {

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -34,7 +34,7 @@ public class Comment {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(updatable = false, nullable = false)
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
     public void update(String content) {

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -4,37 +4,48 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Comment {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "article_id")
+    @JoinColumn(name = "article_id", nullable = false)
     private Article article;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
     @Column(length = 300)
     private String content;
 
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
+    @Column(updatable = false, nullable = false)
     private LocalDateTime updatedAt;
 
-    private Comment(Article article, Member member, String content) {
-        this.article = article;
-        this.member = member;
+    public void update(String content) {
         this.content = content;
     }
 
     public static Comment of(Article article, Member member, String content) {
-        return new Comment(article, member, content);
+        Comment comment = new Comment();
+        comment.article = article;
+        comment.member = member;
+        comment.content = content;
+        return comment;
     }
 }

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -1,0 +1,40 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @Column(length = 300)
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Comment(Article article, Member member, String content) {
+        this.article = article;
+        this.member = member;
+        this.content = content;
+    }
+
+    public static Comment of(Article article, Member member, String content) {
+        return new Comment(article, member, content);
+    }
+}

--- a/src/main/java/org/sopt/domain/Member.java
+++ b/src/main/java/org/sopt/domain/Member.java
@@ -1,12 +1,17 @@
 package org.sopt.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
         @Index(name = "idx_member_name", columnList = "name")
 })
@@ -26,9 +31,7 @@ public class Member {
     private Sex sex;
 
     @OneToMany(mappedBy="member", cascade=CascadeType.ALL)
-    private List<Article> articles;
-
-    protected Member() {}
+    private List<Article> articles = new ArrayList<>();
 
     // private 생성자 (외부에서 직접 생성 방지)
     private Member(String name, LocalDate birthDate, String email, Sex sex) {
@@ -40,25 +43,5 @@ public class Member {
 
     public static Member of(String name, LocalDate birthDate, String email, Sex sex) {
         return new Member(name, birthDate, email, sex);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public LocalDate getBirthDate() {
-        return birthDate;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public Sex getSex() {
-        return sex;
     }
 }

--- a/src/main/java/org/sopt/domain/Member.java
+++ b/src/main/java/org/sopt/domain/Member.java
@@ -21,12 +21,16 @@ public class Member {
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
     private LocalDate birthDate;
 
+    @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Sex sex;
 

--- a/src/main/java/org/sopt/domain/Member.java
+++ b/src/main/java/org/sopt/domain/Member.java
@@ -33,8 +33,7 @@ public class Member {
     @OneToMany(mappedBy="member", cascade=CascadeType.ALL)
     private List<Article> articles = new ArrayList<>();
 
-    // private 생성자 (외부에서 직접 생성 방지)
-    private Member(String name, LocalDate birthDate, String email, Sex sex) {
+    public void update(String name, LocalDate birthDate, String email, Sex sex) {
         this.name = name;
         this.birthDate = birthDate;
         this.email = email;
@@ -42,6 +41,11 @@ public class Member {
     }
 
     public static Member of(String name, LocalDate birthDate, String email, Sex sex) {
-        return new Member(name, birthDate, email, sex);
+        Member member = new Member();
+        member.name = name;
+        member.birthDate = birthDate;
+        member.email = email;
+        member.sex = sex;
+        return member;
     }
 }

--- a/src/main/java/org/sopt/dto/request/CommentCreateRequest.java
+++ b/src/main/java/org/sopt/dto/request/CommentCreateRequest.java
@@ -1,0 +1,16 @@
+package org.sopt.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CommentCreateRequest(
+        @NotNull(message = "아티클 ID를 입력해주세요")
+        Long articleId,
+
+        @NotNull(message = "작성자 ID를 입력해주세요")
+        Long memberId,
+
+        @NotBlank(message = "내용을 입력해주세요")
+        String content
+) {
+}

--- a/src/main/java/org/sopt/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/org/sopt/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,6 @@
+package org.sopt.dto.request;
+
+public record CommentUpdateRequest(
+        String content
+) {
+}

--- a/src/main/java/org/sopt/dto/response/ArticleResponse.java
+++ b/src/main/java/org/sopt/dto/response/ArticleResponse.java
@@ -4,6 +4,7 @@ import org.sopt.domain.Article;
 import org.sopt.domain.Tag;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record ArticleResponse(
         Long id,
@@ -11,9 +12,12 @@ public record ArticleResponse(
         String title,
         String content,
         Tag tag,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        List<Comment> comment
 ) {
     public record Author(Long memberId, String name) {}
+
+    public record Comment(Long commentId, Long memberId, String comment) {}
 
     public static ArticleResponse from(Article article) {
         return new ArticleResponse(
@@ -25,7 +29,14 @@ public record ArticleResponse(
                 article.getTitle(),
                 article.getContent(),
                 article.getTag(),
-                article.getCreatedAt()
+                article.getCreatedAt(),
+                article.getComments().stream()
+                        .map(comment -> new Comment(
+                                comment.getId(),
+                                comment.getMember().getId(),
+                                comment.getContent()
+                        ))
+                        .toList()
         );
     }
 }

--- a/src/main/java/org/sopt/dto/response/ArticleResponse.java
+++ b/src/main/java/org/sopt/dto/response/ArticleResponse.java
@@ -13,7 +13,7 @@ public record ArticleResponse(
         String content,
         Tag tag,
         LocalDateTime createdAt,
-        List<Comment> comment
+        List<Comment> comments
 ) {
     public record Author(Long memberId, String name) {}
 

--- a/src/main/java/org/sopt/dto/response/CommentResponse.java
+++ b/src/main/java/org/sopt/dto/response/CommentResponse.java
@@ -1,0 +1,7 @@
+package org.sopt.dto.response;
+
+public record CommentResponse(
+
+) {
+
+}

--- a/src/main/java/org/sopt/dto/response/CommentResponse.java
+++ b/src/main/java/org/sopt/dto/response/CommentResponse.java
@@ -1,7 +1,35 @@
 package org.sopt.dto.response;
 
+import org.sopt.domain.Comment;
+
+import java.time.LocalDateTime;
+
 public record CommentResponse(
-
+        Long id,
+        Article article,
+        Writer writer,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
+    public record Article(Long id, String title) {}
 
+    public record Writer(Long id, String name) {}
+
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                new Article(
+                        comment.getArticle().getId(),
+                        comment.getArticle().getTitle()
+                ),
+                new Writer(
+                        comment.getMember().getId(),
+                        comment.getMember().getName()
+                ),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
 }

--- a/src/main/java/org/sopt/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/org/sopt/service/ArticleServiceImpl.java
+++ b/src/main/java/org/sopt/service/ArticleServiceImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.common.ErrorCode;
 import org.sopt.domain.Article;
 import org.sopt.domain.Member;
@@ -14,15 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class ArticleServiceImpl implements ArticleService {
 
     private final ArticleRepository articleRepository;
     private final MemberRepository memberRepository;
-
-    public ArticleServiceImpl(ArticleRepository articleRepository, MemberRepository memberRepository) {
-        this.articleRepository = articleRepository;
-        this.memberRepository = memberRepository;
-    }
 
     // 아티클 생성
     @Transactional

--- a/src/main/java/org/sopt/service/CommentService.java
+++ b/src/main/java/org/sopt/service/CommentService.java
@@ -10,5 +10,5 @@ public interface CommentService {
 
     void delete(Long commentId);
 
-    void update(Long commentId, String content);
+    CommentResponse update(Long commentId, String content);
 }

--- a/src/main/java/org/sopt/service/CommentService.java
+++ b/src/main/java/org/sopt/service/CommentService.java
@@ -1,0 +1,14 @@
+package org.sopt.service;
+
+import org.sopt.dto.response.CommentResponse;
+
+public interface CommentService {
+
+    Long create(Long articleId, Long memberId, String content);
+
+    CommentResponse findById(Long id);
+
+    void delete(Long commentId);
+
+    void update(Long commentId, String content);
+}

--- a/src/main/java/org/sopt/service/CommentServiceImpl.java
+++ b/src/main/java/org/sopt/service/CommentServiceImpl.java
@@ -22,13 +22,17 @@ public class CommentServiceImpl implements CommentService {
     private final MemberRepository memberRepository;
     private final ArticleRepository articleRepository;
 
+
+    // 댓글 생성
     @Transactional
     public Long create(Long articleId, Long memberId, String content) {
         Article article = articleRepository.findById(articleId).orElseThrow(
-                () -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
+                () -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND)
+        );
 
         Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                () -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND)
+        );
 
         Comment comment = Comment.of(article, member, content);
 
@@ -37,14 +41,32 @@ public class CommentServiceImpl implements CommentService {
         return comment.getId();
     }
 
+    // 댓글 조회
     public CommentResponse findById(Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND)
+        );
 
+        return CommentResponse.from(comment);
     }
-
+    
+    // 댓글 삭제
+    @Transactional
     public void delete(Long commentId) {
-
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND)
+        );
+        commentRepository.delete(comment);
     }
+    
+    // 댓글 수정
+    @Transactional
+    public CommentResponse update(Long commentId, String content) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND)
+        );
+        comment.update(content);
 
-    public void update(Long commentId, String content) {
+        return CommentResponse.from(comment);
     }
 }

--- a/src/main/java/org/sopt/service/CommentServiceImpl.java
+++ b/src/main/java/org/sopt/service/CommentServiceImpl.java
@@ -1,0 +1,50 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.ErrorCode;
+import org.sopt.domain.Article;
+import org.sopt.domain.Comment;
+import org.sopt.domain.Member;
+import org.sopt.dto.response.CommentResponse;
+import org.sopt.exception.BusinessException;
+import org.sopt.repository.ArticleRepository;
+import org.sopt.repository.CommentRepository;
+import org.sopt.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final ArticleRepository articleRepository;
+
+    @Transactional
+    public Long create(Long articleId, Long memberId, String content) {
+        Article article = articleRepository.findById(articleId).orElseThrow(
+                () -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Comment comment = Comment.of(article, member, content);
+
+        commentRepository.save(comment);
+
+        return comment.getId();
+    }
+
+    public CommentResponse findById(Long commentId) {
+
+    }
+
+    public void delete(Long commentId) {
+
+    }
+
+    public void update(Long commentId, String content) {
+    }
+}

--- a/src/main/java/org/sopt/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/service/MemberServiceImpl.java
@@ -58,23 +58,19 @@ public class MemberServiceImpl implements MemberService {
 
     // 회원 업데이트
     @Transactional
-    public MemberResponse update(Long memberId, MemberUpdateRequest request) {
-        Member existingMember = memberRepository.findById(memberId)
+    public MemberResponse update(Long memberId, MemberUpdateRequest req) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        if (!existingMember.getEmail().equals(request.email())) {
-            validateDuplicateEmail(request.email());
+        if (!member.getEmail().equals(req.email())) {
+            validateDuplicateEmail(req.email());
         }
 
-        validateAdult(request.birthDate());
+        validateAdult(req.birthDate());
 
-        Member updatedMember = Member.of(
-                request.name(),
-                request.birthDate(),
-                request.email(),
-                request.sex()
-        );
-        return MemberResponse.from(updatedMember);
+        member.update(req.name(), req.birthDate(), req.email(), req.sex());
+
+        return MemberResponse.from(member);
     }
     
     // 이메일 중복체크

--- a/src/main/java/org/sopt/service/MemberServiceImpl.java
+++ b/src/main/java/org/sopt/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.common.ErrorCode;
 import org.sopt.domain.Member;
 import org.sopt.domain.Sex;
@@ -15,13 +16,10 @@ import java.time.Period;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-
-    public MemberServiceImpl(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
     
     // 회원 추가
     @Transactional


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 앱잼 신청
- [x] 기획경선 및 밋업 참여
- [x] 댓글 기능 추가

<br>

### 선택과제
- [ ] 캐싱으로 성능 최적화
- [ ] 대용량 데이터 처리 및 정렬 최적화
- [ ] 인프라 설계 시각화
- [ ] 테스트 코드 도입
- [ ] 기능 디벨롭 및 성능 개선


<br>

### **구현한 내용에 대해서 설명해주세요**

#### 1. 댓글(Comment) CRUD 기능 구현
- **엔티티 설계**
  - `Comment` 엔티티 생성
  - Article, Member와의 다대일 양방향 연관관계 설정
  - JPA Auditing을 활용한 생성/수정 시간 자동 관리

- **API 엔드포인트**
  - `POST /api/v1/comments` - 댓글 생성
  - `GET /api/v1/comments/{id}` - 댓글 조회
  - `PATCH /api/v1/comments/{id}` - 댓글 수정
  - `DELETE /api/v1/comments/{id}` - 댓글 삭제

- **서비스 로직**
  - 댓글 생성 시 Article과 Member 존재 여부 검증
  - 트랜잭션 관리를 통한 데이터 정합성 보장
  - 비즈니스 예외 처리

#### 2. Article 조회 API 응답 필드 수정
- **ArticleResponse 구조 변경**
  - 기존 응답에 `comments` 필드 추가
  - 아티클 조회 시 해당 아티클에 달린 댓글 목록도 함께 반환
  - Nested DTO 구조: `Comment(commentId, memberId, comment)`

- **N+1 문제 해결**
  - Fetch Join을 활용한 Article-Comment 연관관계 최적화
  - 아티클 조회 시 댓글 데이터를 한 번의 쿼리로 가져옴

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

#### JPA에서의 올바른 업데이트 방법
댓글 수정 및 회원 수정 기능을 구현하면서 JPA의 업데이트 메커니즘에 대해 깊이 고민했습니다.

**고민한 내용:**
1. **변경 감지(Dirty Checking) vs 명시적 save() 호출**
   - JPA는 영속 상태의 엔티티 변경을 자동 감지하여 UPDATE 쿼리를 생성합니다
   - 트랜잭션 범위 내에서 엔티티를 조회 후 값을 변경하면, `save()` 없이도 자동으로 DB에 반영됩니다

2. **업데이트 로직의 위치**
   - 엔티티 내부에 `update()` 메서드를 두어 응집도를 높였습니다
   - 서비스 계층에서 setter를 직접 호출하지 않고 도메인 메서드를 호출하는 방식을 선택했습니다

3. **트랜잭션 범위의 중요성**
   - `@Transactional` 어노테이션이 없으면 변경 감지가 작동하지 않습니다
   - 읽기 전용 트랜잭션(`readOnly = true`)에서는 변경 감지가 동작하지 않음을 확인했습니다

**결론**

이번 과제에서는 **변경 감지(Dirty Checking)** 방식을 선택했습니다.

**선택 이유**
1. **JPA의 철학에 부합**: 영속성 컨텍스트가 엔티티의 생명주기를 관리
2. **코드의 간결성**: 불필요한 `save()` 호출 제거
3. **도메인 주도 설계**: 엔티티 내부에 `update()` 메서드를 두어 응집도 향상
4. **성능 최적화**: 변경된 필드만 UPDATE